### PR TITLE
Fixed the calculation of hour, minutes, seconds and milliseconds when sh...

### DIFF
--- a/srt_shift.py
+++ b/srt_shift.py
@@ -5,6 +5,8 @@ def main():
   try:
     filename = sys.argv[1]
     shift = float(sys.argv[2])
+    override = sys.argv[3]
+  
   except IndexError, ValueError:
     print "usage: srt-shift filename shift"
     return
@@ -43,8 +45,11 @@ def main():
         
         def shift_time(time):
           shift
-          time[1] += (time[2] + shift) / 60
-          time[2] = (time[2] + shift) % 60
+          new_shift = int(shift) + int((time[3] + (shift-int(shift))*1000) / 1000)
+          time[1] += int((time[2] + new_shift) / 60)
+          time[2] = (time[2] + new_shift) % 60
+          time[3] = int((time[3] + (shift-int(shift))*1000) % 1000)		  
+
           return time
         
         start, end = map(shift_time, (start, end))
@@ -62,8 +67,11 @@ def main():
         
       elif i >= 3:
         out += '%s\n' % line
-  
-  print out
+
+  if override == "override":
+    out_file = open(filename, "w")
+    out_file.write(out)
+    out_file.close()
 
 if __name__ == '__main__':
   main()


### PR DESCRIPTION
...ift is a float number

This fixed the error when using float number in line: 
out += '%s:%s:%s,%s --> %s:%s:%s,%s\n'

Also added an override option. If the third input parameter is "override" then save the result in the original file.